### PR TITLE
ix(v0.5.0): resolve PROD regressions in repository API and missing test assets

### DIFF
--- a/app/core/insights/repository.py
+++ b/app/core/insights/repository.py
@@ -360,24 +360,31 @@ class InsightRepository:
         finally:
             conn.close()
 
-    def get_evidence(self, insight_id: str, limit: int = 20) -> List[dict]:
+    def get_evidence(self, insight_id: str, limit: int = 20, active_only: bool = True) -> List[dict]:
         """
         Get detailed evidence (content + location) for an insight.
         """
         conn = self._get_conn()
         cursor = conn.cursor()
         try:
-            cursor.execute("""
+            query = """
                 SELECT
                     c.chunk_id, c.content_text, c.page, c.slide, c.section,
-                    a.filename, a.path
+                    a.filename, a.path, c.artifact_id
                 FROM insight_evidence ie
                 JOIN chunks c ON c.chunk_id = ie.chunk_id
                 JOIN artifacts a ON a.id = c.artifact_id
                 WHERE ie.insight_id = ?
-                  AND c.is_active = 1
-                LIMIT ?
-            """, (insight_id, limit))
+            """
+            params = [insight_id]
+            
+            if active_only:
+                query += " AND c.is_active = 1"
+                
+            query += " LIMIT ?"
+            params.append(limit)
+            
+            cursor.execute(query, params)
             rows = cursor.fetchall()
             return [
                 {
@@ -388,8 +395,42 @@ class InsightRepository:
                     "section": r[4],
                     "filename": r[5],
                     "path": r[6],
+                    "artifact_id": r[7], 
                 }
                 for r in rows
             ]
+        finally:
+            conn.close()
+
+    def get_status_history(self, insight_id: str) -> List[dict]:
+        conn = self._get_conn()
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute("""
+                SELECT * FROM insight_status_history 
+                WHERE insight_id = ? 
+                ORDER BY changed_at DESC
+            """, (insight_id,))
+            return [dict(row) for row in cur.fetchall()]
+        finally:
+            conn.close()
+
+    def get_latest_quality_metrics(self) -> Optional[dict]:
+        """
+        Fetches the most recent quality metrics entry.
+        """
+        conn = self._get_conn()
+        conn.row_factory = sqlite3.Row
+        try:
+            # Check if table exists first (in case of old DBs)
+            exists = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='quality_metrics'").fetchone()
+            if not exists:
+                return None
+                
+            cur = conn.execute("SELECT * FROM quality_metrics ORDER BY recorded_at DESC LIMIT 1")
+            row = cur.fetchone()
+            return dict(row) if row else None
+        except Exception:
+            return None
         finally:
             conn.close()

--- a/app/test_support/db_factory.py
+++ b/app/test_support/db_factory.py
@@ -1,0 +1,45 @@
+
+import os
+import sqlite3
+import pytest
+import uuid
+import logging
+
+# Path to migrations
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+MIGRATIONS_DIR = os.path.join(PROJECT_ROOT, "db", "migrations")
+
+def create_test_db(tmp_path):
+    """
+    Creates a temporary database and applies all strict migrations.
+    Returns the absolute path to the db file.
+    """
+    db_path = str(tmp_path / f"test_db_{uuid.uuid4()}.sqlite")
+    
+    # Apply migrations
+    # Handle both full repo path and relative path fallbacks
+    try:
+        if os.path.exists(MIGRATIONS_DIR):
+            mig_files = sorted([f for f in os.listdir(MIGRATIONS_DIR) if f.endswith(".sql")])
+            current_mig_dir = MIGRATIONS_DIR
+        else:
+            current_mig_dir = os.path.abspath("db/migrations")
+            mig_files = sorted([f for f in os.listdir(current_mig_dir) if f.endswith(".sql")])
+    except FileNotFoundError:
+         current_mig_dir = "db/migrations"
+         mig_files = sorted([f for f in os.listdir(current_mig_dir) if f.endswith(".sql")])
+        
+    conn = sqlite3.connect(db_path)
+    try:
+        # Enable WAL for tests too
+        conn.execute("PRAGMA journal_mode=WAL;")
+        
+        for mig in mig_files:
+            mig_path = os.path.join(current_mig_dir, mig)
+            with open(mig_path, 'r', encoding='utf-8') as f:
+                script = f.read()
+                conn.executescript(script)
+    finally:
+        conn.close()
+        
+    return db_path

--- a/tests/test_manual_refinements.py
+++ b/tests/test_manual_refinements.py
@@ -1,0 +1,79 @@
+
+import pytest
+from app.core.insights.service import InsightService
+from app.core.insights.explainability_service import ExplainabilityService
+from app.core.insights.models import Insight
+from app.test_support.db_factory import create_test_db
+from app.core.insights.repository import InsightRepository
+
+@pytest.fixture
+def db_path(tmp_path):
+    return create_test_db(tmp_path)
+
+def test_manual_update_without_run_id_fallback(db_path):
+    repo = InsightRepository(db_path)
+    
+    # Create an insight without a run (simulate fresh DB manually seeded or minimal state)
+    iid = "test_manual_1"
+    insight = Insight(
+        insight_id=iid,
+        index_run_id="run_1", 
+        type="decision",
+        statement="Test manual update",
+        status="open",
+        confidence=0.9,
+        evidence_chunk_ids=[],
+        insight_key="key_1"
+    )
+    repo.upsert_insight(insight)
+    
+    # Simulate UI behavior: get_latest_run_id might be None if stats missing
+    # ensuring fallback works
+    latest_run = repo.get_latest_run_id() or 'manual_update'
+    
+    repo.set_status(
+        insight_id=iid,
+        status="resolved",
+        origin="manual",
+        comment="Manually fixing",
+        run_id=latest_run
+    )
+    
+    # Verify history
+    history = repo.get_status_history(iid)
+    assert len(history) >= 1
+    last = history[0]
+    assert last['to_status'] == 'resolved'
+    assert last['origin'] == 'manual'
+    assert last['comment'] == 'Manually fixing'
+    # Run ID should be preserved as passed (fallback or actual)
+    assert last['run_id'] == latest_run 
+    if not repo.get_latest_run_id():
+        assert last['run_id'] == 'manual_update'
+
+def test_explainability_logic_determinism(db_path):
+    repo = InsightRepository(db_path)
+    svc = ExplainabilityService(repo)
+    
+    iid = "test_expl_1"
+    # Seed history: Open -> Resolved
+    repo.log_status_change(iid, "open", "resolved", "manual", "Fixed it", "run_x")
+    
+    # Mock finding insight
+    insight = Insight(
+        insight_id=iid,
+        index_run_id="run_x",
+        type="decision",
+        statement="Expl test",
+        status="resolved",
+        status_origin="manual",
+        confidence=1.0, 
+        insight_key="key_expl",
+        updated_at="2025-01-01 12:00:00"
+    )
+    repo.upsert_insight(insight)
+    
+    # Generate explanation
+    expl = svc.generate_explanation(iid)
+    assert "Resolved manually" in expl.status_logic
+    assert "Fixed it" in expl.status_logic


### PR DESCRIPTION
This PR addresses critical regressions identified in the v0.5.0 deployment:

Repository API Fixes:
Restored missing 
get_status_history
 method ensuring Ignorance Map loads correctly.
Restored 
get_latest_quality_metrics
 for the Quality Dashboard.
Updated 
get_evidence
 signature to support active_only argument, fixing the TypeError in Open Loops.
Test Infrastructure:
Restored app/test_support module and tests/test_manual_refinements.py which were accidentally removed, ensuring regression tests can run successfully.
Verification:

Local regression tests (tests/test_manual_refinements.py, tests/test_insight_lifecycle.py) passed successfully.
Confirmed existence of required migration files (007_insight_lifecycle.sql) for fresh deployment.



